### PR TITLE
Remove 60dc links + small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A local '.env.development' file containing the env variables.
 
 ### Environment Variables
 
-| SPACE_ID                             | Contenful space ID                          |
-| CONTENTFUL_DELIVERY_API_ACCESS_TOKEN | Contenful access tocken                     |
-| GOV_DELIVERY_API_KEY                 | Api key for the gov delivery newsletter Api |
+| CONTENTFUL_SPACE_ID | Contenful space ID |
+| CONTENTFUL_ACCESS_TOKEN | Contenful access token |
+| CONTENTFUL_HOST | Contentful host url (defaults to production) |
+| GOV_DELIVERY_API_KEY | Api key for the gov delivery newsletter Api |

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -11,7 +11,7 @@ const FooterNav = () => {
       nav2Label
       nav3Label
       nav4Label
-      nav5Label
+      # nav5Label
       nav6Label
       credit                   
     }
@@ -31,7 +31,6 @@ const FooterNav = () => {
               <a href="https://www.essex.gov.uk/cookies">{data.contentfulFooterNav.nav2Label}</a></li><li>
               <a href="https://www.essex.gov.uk/terms-conditions">{data.contentfulFooterNav.nav3Label}</a></li><li>
               <a href="https://www.essex.gov.uk/topic/privacy-and-data-protection">{data.contentfulFooterNav.nav4Label}</a></li><li>
-              <Link to="/terms-and-conditions">{data.contentfulFooterNav.nav5Label}</Link></li><li>
               <Link to="/site-map">{data.contentfulFooterNav.nav6Label}</Link></li>
           </ul>
           <ul className="social-icons">

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -10,7 +10,7 @@ const MainNav = () => {
       nav1Label
       nav2Label
       nav3Label
-      nav4Label
+      # nav4Label
       nav5Label                      
     }
   }
@@ -29,7 +29,6 @@ const MainNav = () => {
             <li><a href="/">{data.contentfulMainNav.nav1Label}</a></li>
             <li><a href="/about-us">{data.contentfulMainNav.nav2Label}</a></li>
             <li><a href="/get-started">{data.contentfulMainNav.nav3Label}</a></li>
-            <li><a href="/60-day-challenge">{data.contentfulMainNav.nav4Label}</a></li>
             <li className="pipe">|</li>
             <li><a href="/getting-to-school">{data.contentfulMainNav.nav5Label}</a></li>
           </ul>

--- a/src/html.js
+++ b/src/html.js
@@ -11,7 +11,7 @@ export default function HTML(props) {
           }}
       />
       {/* End Google Tag Manager */}
-        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossOrigin="anonymous" />
         <meta charSet="utf-8" />
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
         <meta
@@ -33,7 +33,7 @@ export default function HTML(props) {
           __html: `(function _(a,b,c,d,e){var f=window.console;f&&Math.floor(new Date().getTime()/1e3)-b>7*24*60*60&&f.warn("The Facebook JSSDK is more than 7 days old.");if(window[c])return;if(!window.JSON)return;var g=window[c]={__buffer:{replay:function(){var a=this,b=function(d){var b=window[c];a.calls[d][0].split(".").forEach(function(a){return b=b[a]});b.apply(null,a.calls[d][1])};for(var d=0;d<this.calls.length;d++)b(d);this.calls=[]},calls:[],opts:null},getUserID:function(){return""},getAuthResponse:function(){return null},getAccessToken:function(){return null},init:function(a){g.__buffer.opts=a}};for(var b=0;b<d.length;b++){f=d[b];if(f in g)continue;var h=f.split("."),i=h.pop(),j=g;for(var k=0;k<h.length;k++)j=j[h[k]]||(j[h[k]]={});j[i]=function(a){if(a==="init")return;return function(){g.__buffer.calls.push([a,Array.prototype.slice.call(arguments)])}}(f)}k=a;h=/Chrome\/(\d+)/.exec(navigator.userAgent);h&&Number(h[1])>=55&&"assign"in Object&&"findIndex"in[]&&(k+="&ua=modern_es6");j=document.createElement("script");j.src=k;j.async=!0;e&&(j.crossOrigin="anonymous");i=document.getElementsByTagName("script")[0];i.parentNode&&i.parentNode.insertBefore(j,i)})("https:\/\/connect.facebook.net\/en_GB\/sdk.js?hash=0bfa37b35fa41379d0fe1b083453e5f9", 1598351937, "FB", ["AppEvents.EventNames","AppEvents.ParameterNames","AppEvents.activateApp","AppEvents.clearAppVersion","AppEvents.clearUserID","AppEvents.getAppVersion","AppEvents.getUserID","AppEvents.logEvent","AppEvents.logPageView","AppEvents.logPurchase","AppEvents.setAppVersion","AppEvents.setUserID","AppEvents.updateUserProperties","Canvas.Plugin.showPluginElement","Canvas.Plugin.hidePluginElement","Canvas.Prefetcher.addStaticResource","Canvas.Prefetcher.setCollectionMode","Canvas.getPageInfo","Canvas.scrollTo","Canvas.setAutoGrow","Canvas.setDoneLoading","Canvas.setSize","Canvas.setUrlHandler","Canvas.startTimer","Canvas.stopTimer","Event.subscribe","Event.unsubscribe","XFBML.parse","addFriend","api","getAccessToken","getAuthResponse","getLoginStatus","getUserID","init","login","logout","publish","share","ui"], true);</script>`,
         }}
       />      
-      <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v8.0" nonce="6fNaox8B"></script>
+      <script async defer crossOrigin="anonymous" src="https://connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v8.0" nonce="6fNaox8B"></script>
         {props.preBodyComponents}
         <div
           key={`body`}

--- a/src/pages/getting-to-school.js
+++ b/src/pages/getting-to-school.js
@@ -77,7 +77,7 @@ const IndexPage = () => {
   return (
     <Layout>
     <Helmet>
-      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous" />
+      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossOrigin="anonymous" />
     </Helmet>
     <div className="mantra" id="get-ready">
       {documentToReactComponents(data.contentfulGettingToSchool.intro.json)}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -49,7 +49,7 @@ const IndexPage = () => {
   return (
     <Layout>
     <Helmet>
-      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous" />
+      <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossOrigin="anonymous" />
     </Helmet>
     <div className="mantra" id="get-ready">
       {documentToReactComponents(data.contentfulLanding.intro.json)}


### PR DESCRIPTION
Removes the header + footer links relating to the 60 day challenge (commenting out the relevant `navLabels` in queries).
Also fixes crossOrigin attribute naming within react code (`crossorigin` -> `crossOrigin`)
Lastly updates the readme to ensure the env variables have a consistent naming to what the config + envs expect.